### PR TITLE
Fix env error on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ prod:
     <<: *common
     loglevel: warn
     storage: s3
-    s3_access_key: _env:AWS_S3_ACCESS_KEY
-    s3_secret_key: _env:AWS_S3_SECRET_KEY
-    s3_bucket: _env:AWS_S3_BUCKET
-    boto_bucket: _env:AWS_S3_BUCKET
+    s3_access_key: _env:AWS_ACCESS_KEY
+    s3_secret_key: _env:AWS_SECRET_KEY
+    s3_bucket: _env:AWS_BUCKET
+    boto_bucket: _env:AWS_BUCKET
     storage_path: /srv/docker
     smtp_host: localhost
     from_addr: docker@myself.com


### PR DESCRIPTION
The correct env is AWS_ACCESS_KEY not AWS_S3_ACCESS_KEY, I have fixed the README.md
